### PR TITLE
Make docs-build pixi task place CNAME file correctly

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -380,7 +380,7 @@ packages:
 - pypi: ./
   name: docs-catalyst-coop
   version: 0.1.0
-  sha256: 243190d11959b5f23d8a2d93320196e91937469d1b2be30d69f6f003a7024528
+  sha256: f04121f10988d73c3e684d5df6417ce60c03d1c06f5603cf19e23bb677b99b82
   requires_python: '>=3.14'
 - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
   sha256: 0d605569a77350fb681f9ed8d357cc71649b59a304099dc9d09fbeec5e84a65e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ docs-catalyst-coop = { path = ".", editable = true }
 
 [tool.pixi.tasks.docs-build]
 cmd = """
-python -m sphinx --jobs auto -W -b html src build/html
+python -m sphinx --jobs auto -W -b html src build/html && cp CNAME build/html
 """
 description = "Build PUDL docs using Sphinx"
 

--- a/src/conf.py
+++ b/src/conf.py
@@ -13,7 +13,6 @@ copyright = (  # noqa: A001
     f"2016-{datetime.date.today().year}, Catalyst Cooperative, CC-BY-4.0"
 )
 author = "Catalyst Cooperative"
-release = "2026.4.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview


We had the CNAME file in gh-pages, and we had it in the root of this repo, but building the docs clobbered the gh-pages copy and the root copy was getting dropped on the floor :sob:

What problem does this address?

docs.catalyst.coop 404s after a build!

What did you change in this PR?

* Place CNAME file as part of docs-build pixi task
* Bonus unrelated fix: we don't need no release numbers

I'm not sure why CNAME was getting clobbered but not .nojekyll, but this fix should work regardless.

# Testing

How did you make sure this worked? How can a reviewer verify this?

* Built and browsed locally
* Verified CNAME ends up in build/html, which is the dir that gets uploaded to gh-pages by GHA

# To-do list

- [x] Review the PR yourself and call out any questions or issues you have

